### PR TITLE
Minor improvements

### DIFF
--- a/uCVE.go
+++ b/uCVE.go
@@ -1187,6 +1187,7 @@ func check_list_vendor_product_flag(list_vendor_product bool) {
 
 func check_search_product_literal_flag(search_product_literal string) {
 	if (search_product_literal != "") {
+		search_product_literal = strings.ToLower(search_product_literal)
 		fmt.Println("[" + string_color("green", "+") + "] " + string_color("green", "Search literal") + " product '" + string_color("green", search_product_literal) + "' in '" + string_color("green", FILENAME_LVP) + "'")
 		fmt.Println()
 		matches := search_products_in_lvp(search_product_literal, "literal")

--- a/uCVE.go
+++ b/uCVE.go
@@ -1202,6 +1202,7 @@ func check_search_product_literal_flag(search_product_literal string) {
 
 func check_search_product_contains_flag(search_product_contains string) {
 	if (search_product_contains != "") {
+		search_product_contains = strings.ToLower(search_product_contains)
 		fmt.Println("[" + string_color("green", "+") + "] " + string_color("green", "Search contains") + " product '" + string_color("green", search_product_contains) + "' in '" + string_color("green", FILENAME_LVP) + "'")
 		fmt.Println()
 		matches := search_products_in_lvp(search_product_contains, "contains")


### PR DESCRIPTION
I've modified a few things that I missed last time I used the tool, hopefully you will find it worth it to include.

### Turn -spl and -spc into case insensitive
Pretty self explanatory, now the product search is case insensitive. Given the list the flag is looked up in is all lowercase, so is the flag value now.

### Add -l flag to set a max number of retrieved CVEs
There was a time the product I needed CVEs from had more than 6k CVEs and the tool was really taking forever. I only needed the output table and a bunch of CVEs so this new flag is meant to limit the retrieved CVEs. Moreover it may speed up search tests.

Please note it does not sort the results to get the highests CVSS first, this is purely for quickly getting a table with CVEs regardless the amount it really has.